### PR TITLE
Enable db-less mode with declarative config string

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,22 +43,28 @@ resource "cloudfoundry_app" "kong" {
     ignore_changes = [instances]
   }
   health_check_type = "process"
-  command           = "/docker-entrypoint.sh /usr/local/bin/kong migrations bootstrap && /docker-entrypoint.sh /usr/local/bin/kong migrations up && /docker-entrypoint.sh kong docker-start"
+  command           = var.enable_postgres ? "/docker-entrypoint.sh /usr/local/bin/kong migrations bootstrap && /docker-entrypoint.sh /usr/local/bin/kong migrations up && /docker-entrypoint.sh kong docker-start" : "/docker-entrypoint.sh kong docker-start"
   environment = merge(var.environment,
     {
-      "KONG_DATABASE"          = "postgres"
-      "KONG_PG_USER"           = module.postgres[0].credentials.username
-      "KONG_PG_PASSWORD"       = module.postgres[0].credentials.password
-      "KONG_PG_HOST"           = module.postgres[0].credentials.hostname
-      "KONG_PG_DATABASE"       = module.postgres[0].credentials.db_name
       "KONG_PLUGINS"           = join(",", var.kong_plugins)
       "KONG_TRUSTED_IPS"       = "0.0.0.0/0"
       "KONG_REAL_IP_HEADER"    = "X-Forwarded-For"
       "KONG_REAL_IP_RECURSIVE" = "on"
       "KONG_PROXY_LISTEN"      = "0.0.0.0:8080 reuseport backlog=16384,0.0.0.0:8000 reuseport backlog=16384,0.0.0.0:8443 http2 ssl reuseport backlog=16384,0.0.0.0:8444 http2 ssl reuseport backlog=16384"
       "KONG_ADMIN_LISTEN"      = "0.0.0.0:8001"
+    }, var.enable_postgres ? {
+      "KONG_DATABASE"          = "postgres"
+      "KONG_PG_USER"           = module.postgres[0].credentials.username
+      "KONG_PG_PASSWORD"       = module.postgres[0].credentials.password
+      "KONG_PG_HOST"           = module.postgres[0].credentials.hostname
+      "KONG_PG_DATABASE"       = module.postgres[0].credentials.db_name
+    } : {
+      "KONG_DATABASE"          = "off"
+      "KONG_DECLARATIVE_CONFIG_STRING" = var.kong_declarative_config_string
     }
+
   )
+
   routes {
     route = cloudfoundry_route.kong.id
   }

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "cloudfoundry_app" "kong" {
       "KONG_PG_HOST"     = module.postgres[0].credentials.hostname
       "KONG_PG_DATABASE" = module.postgres[0].credentials.db_name
       } : {
-      "KONG_DATABASE"    = "off"
+      "KONG_DATABASE"                  = "off"
       "KONG_DECLARATIVE_CONFIG_STRING" = var.kong_declarative_config_string
     }
 

--- a/main.tf
+++ b/main.tf
@@ -52,14 +52,14 @@ resource "cloudfoundry_app" "kong" {
       "KONG_REAL_IP_RECURSIVE" = "on"
       "KONG_PROXY_LISTEN"      = "0.0.0.0:8080 reuseport backlog=16384,0.0.0.0:8000 reuseport backlog=16384,0.0.0.0:8443 http2 ssl reuseport backlog=16384,0.0.0.0:8444 http2 ssl reuseport backlog=16384"
       "KONG_ADMIN_LISTEN"      = "0.0.0.0:8001"
-    }, var.enable_postgres ? {
-      "KONG_DATABASE"          = "postgres"
-      "KONG_PG_USER"           = module.postgres[0].credentials.username
-      "KONG_PG_PASSWORD"       = module.postgres[0].credentials.password
-      "KONG_PG_HOST"           = module.postgres[0].credentials.hostname
-      "KONG_PG_DATABASE"       = module.postgres[0].credentials.db_name
-    } : {
-      "KONG_DATABASE"          = "off"
+      }, var.enable_postgres ? {
+      "KONG_DATABASE"    = "postgres"
+      "KONG_PG_USER"     = module.postgres[0].credentials.username
+      "KONG_PG_PASSWORD" = module.postgres[0].credentials.password
+      "KONG_PG_HOST"     = module.postgres[0].credentials.hostname
+      "KONG_PG_DATABASE" = module.postgres[0].credentials.db_name
+      } : {
+      "KONG_DATABASE"    = "off"
       "KONG_DECLARATIVE_CONFIG_STRING" = var.kong_declarative_config_string
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "environment" {
   default     = {}
 }
 
+variable "kong_declarative_config_string" {
+  type        = string
+  description = "Declarative configuration json for Kong. To be provided while running in db less declarative mode"
+  default     = "{\"_format_version\":\"1.1\", \"services\":[{\"host\":\"hsdp.io\",\"port\":443,\"protocol\":\"https\", \"routes\":[{\"paths\":[\"/\"]}]}],\"plugins\":[{\"name\":\"prometheus\"}]}"
+}
+
 variable "konga_environment" {
   type        = map(any)
   description = "Environment variables for Kong app"


### PR DESCRIPTION
Adding declarative config option.
Changes:
1. Toggling postgres/db-less declarative modes using enable_postgres variable
2. Declarative string added in variables tf file