### PR TITLE
Kong 3.x support upgrade.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "cloudfoundry_app" "kong" {
   }
   strategy          = var.strategy
   health_check_type = "process"
-  command           = var.start_command != "" ? var_start_command : (var.enable_postgres ? "/entrypoint.sh /usr/local/bin/kong migrations bootstrap && /entrypoint.sh /usr/local/bin/kong migrations up && /entrypoint.sh /usr/local/bin/kong migrations finish && /entrypoint.sh kong docker-start" : "/entrypoint.sh kong docker-start")
+  command           = var.start_command != "" ? var.start_command : (var.enable_postgres ? "/entrypoint.sh /usr/local/bin/kong migrations bootstrap && /entrypoint.sh /usr/local/bin/kong migrations up && /entrypoint.sh /usr/local/bin/kong migrations finish && /entrypoint.sh kong docker-start" : "/entrypoint.sh kong docker-start")
   environment = merge({
     KONG_PLUGINS                = join(",", var.kong_plugins)
     KONG_TRUSTED_IPS            = "0.0.0.0/0"

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "cloudfoundry_app" "kong" {
   }
   strategy          = var.strategy
   health_check_type = "process"
-  command           = var.enable_postgres ? "/entrypoint.sh /usr/local/bin/kong migrations bootstrap && /entrypoint.sh /usr/local/bin/kong migrations up && /entrypoint.sh kong docker-start" : "/entrypoint.sh kong docker-start"
+  command           = var.enable_postgres ? "/entrypoint.sh /usr/local/bin/kong migrations bootstrap && /entrypoint.sh /usr/local/bin/kong migrations up && /entrypoint.sh /usr/local/bin/kong migrations finish && /entrypoint.sh kong docker-start" : "/entrypoint.sh kong docker-start"
   environment = merge({
     KONG_PLUGINS                = join(",", var.kong_plugins)
     KONG_TRUSTED_IPS            = "0.0.0.0/0"

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "cloudfoundry_app" "kong" {
   }
   strategy          = var.strategy
   health_check_type = "process"
-  command           = var.enable_postgres ? "/docker-entrypoint.sh /usr/local/bin/kong migrations bootstrap && /docker-entrypoint.sh /usr/local/bin/kong migrations up && /docker-entrypoint.sh kong docker-start" : "/docker-entrypoint.sh kong docker-start"
+  command           = var.enable_postgres ? "/entrypoint.sh /usr/local/bin/kong migrations bootstrap && /entrypoint.sh /usr/local/bin/kong migrations up && /entrypoint.sh kong docker-start" : "/entrypoint.sh kong docker-start"
   environment = merge({
     KONG_PLUGINS                = join(",", var.kong_plugins)
     KONG_TRUSTED_IPS            = "0.0.0.0/0"
@@ -54,11 +54,13 @@ resource "cloudfoundry_app" "kong" {
     KONG_ADMIN_LISTEN           = "0.0.0.0:8001"
     KONG_NGINX_WORKER_PROCESSES = var.kong_nginx_worker_processes
     }, var.enable_postgres ? {
-    KONG_DATABASE    = "postgres"
-    KONG_PG_USER     = module.postgres[0].credentials.username
-    KONG_PG_PASSWORD = module.postgres[0].credentials.password
-    KONG_PG_HOST     = module.postgres[0].credentials.hostname
-    KONG_PG_DATABASE = module.postgres[0].credentials.db_name
+    KONG_DATABASE      = "postgres"
+    KONG_PG_USER       = module.postgres[0].credentials.username
+    KONG_PG_PASSWORD   = module.postgres[0].credentials.password
+    KONG_PG_HOST       = module.postgres[0].credentials.hostname
+    KONG_PG_DATABASE   = module.postgres[0].credentials.db_name
+    KONG_PG_SSL        = "on"
+    KONG_PG_SSL_VERIFY = "off"
     } : {
     KONG_DATABASE                  = "off"
     KONG_DECLARATIVE_CONFIG_STRING = var.kong_declarative_config_string

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "cloudfoundry_app" "kong" {
   }
   strategy          = var.strategy
   health_check_type = "process"
-  command           = var.enable_postgres ? "/entrypoint.sh /usr/local/bin/kong migrations bootstrap && /entrypoint.sh /usr/local/bin/kong migrations up && /entrypoint.sh /usr/local/bin/kong migrations finish && /entrypoint.sh kong docker-start" : "/entrypoint.sh kong docker-start"
+  command           = var.start_command != "" ? var_start_command : (var.enable_postgres ? "/entrypoint.sh /usr/local/bin/kong migrations bootstrap && /entrypoint.sh /usr/local/bin/kong migrations up && /entrypoint.sh /usr/local/bin/kong migrations finish && /entrypoint.sh kong docker-start" : "/entrypoint.sh kong docker-start")
   environment = merge({
     KONG_PLUGINS                = join(",", var.kong_plugins)
     KONG_TRUSTED_IPS            = "0.0.0.0/0"

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "kong_image" {
   type        = string
   description = "Kong Docker image to use"
-  default     = "kong/kong:3.6.1"
+  default     = "kong/kong:3.4.2"
 }
 
 variable "kong_plugins" {

--- a/variables.tf
+++ b/variables.tf
@@ -133,3 +133,9 @@ variable "docker_password" {
   description = "Docker registry password"
   default     = ""
 }
+
+variable "start_command" {
+  type        = string
+  description = "Explicit Docker startup command"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "kong_image" {
   type        = string
   description = "Kong Docker image to use"
-  default     = "kong/kong:2.6.0"
+  default     = "kong/kong:3.6.1"
 }
 
 variable "kong_plugins" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "kong_image" {
   type        = string
   description = "Kong Docker image to use"
-  default     = "kong/kong:3.4.2"
+  default     = "kong/kong:3.5.0"
 }
 
 variable "kong_plugins" {


### PR DESCRIPTION
- [x] Container start commands are reflecting kong layout starting from 3.3.0.
- [x] Container start commands can be redefined through environment to handle operational scenarios like DB migration.
- [x] Default container start command updated to support DB migration from 2.x to 3.x (was not fully implemented).
- [x] In case of Postgres DB by default connection supports SSL (while SSL verification is by default disabled).
- [x] Default Kong container is now kong/kong:3.5.0.
